### PR TITLE
Add `.content` wrapper

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -3,8 +3,10 @@
     <div class="center">Home</div>
   </ons-toolbar>
 
-  <ons-list>
-    <ons-list-header>Dialog Sample</ons-list-header>
-    <ons-list-item (click)="alert()">Alert</ons-list-item>
-  </ons-list>
+  <div class="content">
+    <ons-list>
+      <ons-list-header>Dialog Sample</ons-list-header>
+      <ons-list-item (click)="alert()">Alert</ons-list-item>
+    </ons-list>
+  </div>
 </ons-page>


### PR DESCRIPTION
I think it was discussed that it's better for the bindings to already have a either `.content` or `.page__content`. Even though the simpler version still works right now maybe we should put it in the template if we want users to do it.